### PR TITLE
Fix pangram icon count capped at 3

### DIFF
--- a/src/components/PuzzleInfo.tsx
+++ b/src/components/PuzzleInfo.tsx
@@ -220,7 +220,7 @@ export default function PuzzleInfo({
       )}
       
       <div ref={pangramRef} className="flex gap-0.5">
-        {Array.from({ length: Math.min(pangramCount, 3) }).map((_, index) => (
+        {Array.from({ length: pangramCount }).map((_, index) => (
           <PangramIndicator
             key={index}
             index={index}


### PR DESCRIPTION
## Summary
- Removes `Math.min(pangramCount, 3)` cap so all pangram icons render when a puzzle has more than 3 pangrams

## Test plan
- [ ] Verify today's puzzle (4 pangrams) shows 4 icons
- [ ] Verify puzzles with 1-3 pangrams still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)