### PR TITLE
Match letter tile colors in Yesterday's Puzzle modal to gameboard

### DIFF
--- a/src/components/YesterdaysPuzzleModal.tsx
+++ b/src/components/YesterdaysPuzzleModal.tsx
@@ -176,8 +176,8 @@ export default function YesterdaysPuzzleModal({
                   key={index}
                   className={`w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center rounded-lg text-base sm:text-xl font-bold ${
                     index === 0
-                      ? 'bg-[#2D5A27] text-white'
-                      : 'bg-[#333333] text-white'
+                      ? 'bg-amber-300 text-black'
+                      : 'bg-purple-400 text-black'
                   }`}
                 >
                   {letter}


### PR DESCRIPTION
## Summary
- Center tile in Yesterday's Puzzle modal now uses amber/yellow (`bg-amber-300`) to match the gameboard
- Outer tiles now use purple (`bg-purple-400`) to match the gameboard
- Consistent with the existing How to Play modal tile styling

## Test plan
- [ ] Open Yesterday's Puzzle modal and verify center tile is yellow and outer tiles are purple
- [ ] Confirm styling matches the How to Play modal example tiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)