### PR TITLE
Fix word list not showing in yesterday's modal and definition flicker

### DIFF
--- a/src/components/WordDefinitionContent.tsx
+++ b/src/components/WordDefinitionContent.tsx
@@ -20,7 +20,7 @@ interface WordDefinitionContentProps {
 
 export default function WordDefinitionContent({ word }: WordDefinitionContentProps) {
   const [definition, setDefinition] = useState<WordDefinition | null>(null);
-  const [loading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
   const fetchDefinition = useCallback(async () => {

--- a/src/components/YesterdaysPuzzleModal.tsx
+++ b/src/components/YesterdaysPuzzleModal.tsx
@@ -247,8 +247,8 @@ export default function YesterdaysPuzzleModal({
             </div>
 
             {/* Body — slides between word list and definition view */}
-            <div className="relative flex-1 overflow-hidden">
-              <AnimatePresence initial={false} custom={direction}>
+            <div className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden">
+              <AnimatePresence mode="wait" initial={false} custom={direction}>
                 {selectedWord === null ? (
                   <motion.div
                     key="word-list"
@@ -258,7 +258,7 @@ export default function YesterdaysPuzzleModal({
                     animate="center"
                     exit="exit"
                     transition={slideTransition}
-                    className="absolute inset-0 overflow-y-auto space-y-4 pr-2"
+                    className="space-y-4 pr-2"
                   >
                     {letterGroups.map(([letter, words]) => (
                       <div key={letter}>
@@ -294,7 +294,7 @@ export default function YesterdaysPuzzleModal({
                     animate="center"
                     exit="exit"
                     transition={slideTransition}
-                    className="absolute inset-0 overflow-y-auto flex flex-col"
+                    className="flex flex-col"
                   >
                     <WordDefinitionContent word={selectedWord} />
                   </motion.div>


### PR DESCRIPTION
Two bugs introduced when WordDefinitionContent was extracted:

1. Yesterday's puzzle shows no words: The body container was changed to use `relative flex-1 overflow-hidden` with `absolute inset-0` children. Because absolutely-positioned elements are out of flow, the body div contributes 0 height to the outer modal's content measurement. With only max-h-[90vh] (no explicit height) on the modal, max-h never clamps, the flex container stays content-sized at ~220px (fixed elements only), and flex-1 distributes 0 remaining space to the body — so overflow-hidden clips the absolute word list to nothing.

   Fix: replace absolute inset-0 children with normal-flow children, change the wrapper to flex-1 min-h-0 overflow-y-auto overflow-x-hidden (the word list's in-flow content makes the modal exceed max-h, which then clamps the flex container and gives flex-1 its proper allocation), and add mode="wait" to AnimatePresence so only one panel is in the DOM at a time (preventing double-stacking during transitions).

2. Definition flickers on tap (main game): WordDefinitionContent initialized loading=false, causing a 1-frame blank render before the spinner appeared. Since getDefinition is async, even cached lookups go through a microtask, so the blank flash always occurred before the spinner showed.

   Fix: initialize loading=true so the spinner renders immediately on mount.

https://claude.ai/code/session_01YJdCWWFBNnKof6pPNDJZkh